### PR TITLE
Compatibility with PHP 7.4 and added ability to insert IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $consent = new ConsentSolution\Consent;
 
 $user_id = 10;
 
-$consent->setSubject( 
+$consent->setSubject(
     [
         'id' => sha1( 'my_application_' . $user_id ), // you can omit this field
         'email' => 'user@example.com',
@@ -31,12 +31,12 @@ $consent->setSubject(
     ]
 );
 
-$consent->addLegalNotice( [ 'identifier' => 'privacy_policy' ] );            
+$consent->addLegalNotice( [ 'identifier' => 'privacy_policy' ] );
 
 $consent->addProof( [
-    'content' => json_encode( [ 
-        'first_name' => 'John', 
-        'last_name' => 'Doe', 
+    'content' => json_encode( [
+        'first_name' => 'John',
+        'last_name' => 'Doe',
         // other useful form fields
     ] ),
     'form' => '<form><input type="text" name="first_name">[...]</form>',
@@ -45,6 +45,8 @@ $consent->addProof( [
 $consent->preferences['privacy_policy'] = true;
 $consent->preferences['third_party'] = false;
 $consent->preferences['newsletter'] = true;
+
+$consent->setIpAddress('192.168.1.254');
 
 try {
     $saved_consent = $consentSolution->createConsent( $consent );
@@ -63,9 +65,9 @@ Copy the file `phpunit.xml.dist` in `phpunit.xml` in the library folder and defi
 
 ```xml
 	<php>
-        <const name="CONSENT_SOLUTION_API_KEY" value="foobar"/>			
-        <const name="CONSENT_SOLUTION_TEST_CONSENT" value="foobar"/>			
-        <const name="CONSENT_SOLUTION_TEST_SUBJECT" value="foobar"/>			        
+        <const name="CONSENT_SOLUTION_API_KEY" value="foobar"/>
+        <const name="CONSENT_SOLUTION_TEST_CONSENT" value="foobar"/>
+        <const name="CONSENT_SOLUTION_TEST_SUBJECT" value="foobar"/>
         ...
 	</php>
 ```

--- a/src/Consent.php
+++ b/src/Consent.php
@@ -98,6 +98,12 @@ class Consent extends ICSObject
      */
     public $source;       
 
+    /**
+     * The IP address of the subject
+     * 
+     * @var string
+    */
+    public $ip_address;
 
     /**
      * Configures the specified content in the class
@@ -128,6 +134,11 @@ class Consent extends ICSObject
             $this->setTimestamp($properties['timestamp']); 
             unset($properties['timestamp']);
         }        
+
+        if (!empty($properties['ip_address']) ) {
+            $this->setIpAddress($properties['ip_address']); 
+            unset($properties['ip_address']);
+        }
       
         parent::configure($properties); 
       
@@ -242,7 +253,19 @@ class Consent extends ICSObject
         }
       
           $this->timestamp = $timestamp;  
-    }    
+    }   
+    
+    /**
+     * Sets the subject IP address
+     * 
+     * @param string $address The IP address
+     * 
+     * @return void
+     */
+    public function setIpAddress( $address )
+    {
+        $this->ip_address = $address;
+    }
 
     /**
      * Cast this object as array
@@ -274,6 +297,10 @@ class Consent extends ICSObject
             $output['source']  = $this->source;
         }  
         
+        if ($this->ip_address  ) {
+            $output['ip_address'] = $this->ip_address;
+        }
+
         if ($this->subject ) {
             $output['subject'] = $this->subject->toArray();
         } else {

--- a/src/Consent.php
+++ b/src/Consent.php
@@ -25,7 +25,7 @@ use DateTime;
  * @version    Release: 1.0
  * @link       https://github.com/silverbackstudio/php-iubenda-consent-solution
  */
-class Consent extends Object
+class Consent extends ICSObject
 {
 
     /**

--- a/src/ICSObject.php
+++ b/src/ICSObject.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Iubenda Consent Obejct Class.
+ * Iubenda Consent Object Class.
  *
  * @category Iubenda
  * @package  ConsentSolution
@@ -21,7 +21,7 @@ namespace Iubenda\ConsentSolution;
  * @version  Release: 1.0
  * @link     https://github.com/silverbackstudio/php-iubenda-consent-solution
  */
-abstract class Object
+abstract class ICSObject
 {
 
     /**

--- a/src/LegalNotice.php
+++ b/src/LegalNotice.php
@@ -24,7 +24,7 @@ use DateTime;
  * @version  Release: 1.0
  * @link     https://github.com/silverbackstudio/php-iubenda-consent-solution
  */
-class LegalNotice extends Object
+class LegalNotice extends ICSObject
 {
 
     /**

--- a/src/Proof.php
+++ b/src/Proof.php
@@ -22,7 +22,7 @@ namespace Iubenda\ConsentSolution;
  * @version  Release: 1.0
  * @link     https://github.com/silverbackstudio/php-iubenda-consent-solution
  */
-class Proof extends Object
+class Proof extends ICSObject
 {
 
     /**

--- a/src/Subject.php
+++ b/src/Subject.php
@@ -24,7 +24,7 @@ use DateTime;
  * @version  Release: 1.0
  * @link     https://github.com/silverbackstudio/php-iubenda-consent-solution
  */
-class Subject extends Object
+class Subject extends ICSObject
 {
 
     /**

--- a/tests/ConsentTest.php
+++ b/tests/ConsentTest.php
@@ -34,7 +34,7 @@ final class ConsentTest extends TestCase
         $this->assertEquals($consent_data['proofs'][0],  $consent->proofs[0]->toArray());
         $this->assertEquals($consent_data['legal_notices'][0], $consent->legal_notices[0]->toArray());
         $this->assertEquals($consent_data['preferences'], $consent->preferences);
-
+        $this->assertEquals($consent_data['ip_address'], $consent->ip_address);
     }
     
     public function testCanSetTimestamp()

--- a/tests/data/consent.json
+++ b/tests/data/consent.json
@@ -26,5 +26,6 @@
     "preferences": {
         "newsletter": false,
         "privacy_policy": true
-    }
+    },
+    "ip_address": "192.168.1.254"
 }


### PR DESCRIPTION
I changed the Object class to ICSObject since in PHP 7.4 Object is now a reserved word.

I also added the ability to specify an IP address for the consent.